### PR TITLE
fixups for directory by listener

### DIFF
--- a/payjoin-directory/src/lib.rs
+++ b/payjoin-directory/src/lib.rs
@@ -53,7 +53,7 @@ pub async fn listen_tcp_with_tls_on_free_port(
 // Helper function to avoid code duplication
 async fn listen_tcp_with_tls_on_listener(
     listener: tokio::net::TcpListener,
-    db_host: String, 
+    db_host: String,
     timeout: Duration,
     tls_config: (Vec<u8>, Vec<u8>),
 ) -> Result<tokio::task::JoinHandle<Result<(), BoxError>>, BoxError> {
@@ -131,7 +131,7 @@ pub async fn listen_tcp(
 pub async fn listen_tcp_with_tls(
     port: u16,
     db_host: String,
-    timeout: Duration, 
+    timeout: Duration,
     cert_key: (Vec<u8>, Vec<u8>),
 ) -> Result<tokio::task::JoinHandle<Result<(), BoxError>>, BoxError> {
     let addr = format!("0.0.0.0:{}", port);

--- a/payjoin-directory/src/lib.rs
+++ b/payjoin-directory/src/lib.rs
@@ -40,11 +40,10 @@ pub async fn listen_tcp_with_tls_on_free_port(
     timeout: Duration,
     cert_key: (Vec<u8>, Vec<u8>),
 ) -> Result<(u16, tokio::task::JoinHandle<Result<(), BoxError>>), BoxError> {
-    let listener = std::net::TcpListener::bind("0.0.0.0:0")?;
+    let listener = tokio::net::TcpListener::bind("[::]:0").await?;
     let port = listener.local_addr()?.port();
-    println!("Directory server binding to port {}", port);
+    println!("Directory server binding to port {}", listener.local_addr()?);
 
-    let listener = tokio::net::TcpListener::from_std(listener)?;
     println!("tokio listener created");
     let handle = listen_tcp_with_tls_on_listener(listener, db_host, timeout, cert_key).await?;
     println!("Directory server started");

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -212,7 +212,7 @@ mod integration {
                     eprintln!("Directory server error: {:?}", e);
                 }
             });
-            
+
             tokio::select!(
                 _ = directory_task => panic!("Directory server is long running"),
                 res = try_request_with_bad_keys(directory, bad_ohttp_keys, cert) => {


### PR DESCRIPTION
the problem was that redis was being shut down prematurely, see long commit message of final fixup commit

different fixes are separated into different commits at your discretion:

1. avoid mixing blocking and tokio listeners, and listen on [::] instead of 0.0.0.0 in line with previous behavior
2. whitespace fixes
3. hideous fix for the docker stuff

i didn't bother making 3 pretty since the commit i was ammending seemed quite WIP, this needs some finessing since `db` borrows from `docker` and both must persist, so i just copypasted that boilerplate into all of the tests that call init_directory to make them work

this seems to be working well now, but i never observed the flakiness myself so not sure how much that counts for
