### PR TITLE
Format Cargo.toml files with taplo

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-name = "payjoin-fuzz"
-version = "0.0.1"
-publish = false
 edition = "2021"
+name = "payjoin-fuzz"
+publish = false
+version = "0.0.1"
 
 [package.metadata]
 cargo-fuzz = true

--- a/ohttp-relay/Cargo.toml
+++ b/ohttp-relay/Cargo.toml
@@ -1,23 +1,23 @@
 [package]
-name = "ohttp-relay"
-version = "0.0.11"
 authors = ["Dan Gould <d@ngould.dev>"]
-description = "Relay Oblivious HTTP requests to protect IP metadata"
-repository = "https://github.com/payjoin/rust-payjoin/tree/master/ohttp-relay"
-readme = "README.md"
-keywords = ["ohttp", "privacy"]
 categories = ["web-programming", "network-programming"]
-license = "MITNFA"
+description = "Relay Oblivious HTTP requests to protect IP metadata"
 edition = "2021"
-rust-version = "1.85.0"
 exclude = ["tests"]
+keywords = ["ohttp", "privacy"]
+license = "MITNFA"
+name = "ohttp-relay"
+readme = "README.md"
+repository = "https://github.com/payjoin/rust-payjoin/tree/master/ohttp-relay"
+rust-version = "1.85.0"
+version = "0.0.11"
 
 [features]
-default = ["bootstrap"]
+_test-util = []
 bootstrap = ["connect-bootstrap", "ws-bootstrap"]
 connect-bootstrap = []
+default = ["bootstrap"]
 ws-bootstrap = ["futures", "rustls", "tokio-tungstenite"]
-_test-util = []
 
 [dependencies]
 byteorder = "1.5.0"

--- a/payjoin-cli/Cargo.toml
+++ b/payjoin-cli/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
-name = "payjoin-cli"
-version = "0.2.0"
 authors = ["Dan Gould <d@ngould.dev>"]
-description = "A command-line Payjoin client for Bitcoin Core"
-repository = "https://github.com/payjoin/rust-payjoin"
-readme = "README.md"
-keywords = ["bip78", "payjoin", "bitcoin"]
 categories = ["cryptography::cryptocurrencies", "network-programming"]
-license = "MITNFA"
+description = "A command-line Payjoin client for Bitcoin Core"
 edition = "2021"
-rust-version = "1.85"
-resolver = "2"
 exclude = ["tests"]
+keywords = ["bip78", "payjoin", "bitcoin"]
+license = "MITNFA"
+name = "payjoin-cli"
+readme = "README.md"
+repository = "https://github.com/payjoin/rust-payjoin"
+resolver = "2"
+rust-version = "1.85"
+version = "0.2.0"
 
 [[bin]]
 name = "payjoin-cli"
@@ -19,9 +19,9 @@ path = "src/main.rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
+_manual-tls = ["reqwest/rustls-tls", "payjoin/_manual-tls", "tokio-rustls"]
 default = ["v2"]
 native-certs = ["reqwest/rustls-tls-native-roots"]
-_manual-tls = ["reqwest/rustls-tls", "payjoin/_manual-tls", "tokio-rustls"]
 v1 = ["payjoin/v1", "hyper", "hyper-util", "http-body-util"]
 v2 = ["payjoin/v2", "payjoin/io"]
 

--- a/payjoin-directory/Cargo.toml
+++ b/payjoin-directory/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
-name = "payjoin-directory"
-version = "0.0.3"
 authors = ["Dan Gould <d@ngould.dev>"]
-description = "A store-and-forward and Oblivious Gateway Resource directory server for Async Payjoin"
-repository = "https://github.com/payjoin/rust-payjoin"
-readme = "README.md"
-keywords = ["bip78", "bip77", "payjoin", "bitcoin", "ohttp"]
 categories = ["cryptography::cryptocurrencies", "network-programming"]
-license = "MITNFA"
+description = "A store-and-forward and Oblivious Gateway Resource directory server for Async Payjoin"
 edition = "2021"
-rust-version = "1.85"
+keywords = ["bip78", "bip77", "payjoin", "bitcoin", "ohttp"]
+license = "MITNFA"
+name = "payjoin-directory"
+readme = "README.md"
+repository = "https://github.com/payjoin/rust-payjoin"
 resolver = "2"
+rust-version = "1.85"
+version = "0.0.3"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/payjoin-ffi/Cargo.toml
+++ b/payjoin-ffi/Cargo.toml
@@ -1,21 +1,21 @@
 [package]
+edition = "2021"
+exclude = ["tests"]
+license = "MIT OR Apache-2.0"
 name = "payjoin-ffi"
 version = "0.24.0"
-edition = "2021"
-license = "MIT OR Apache-2.0"
-exclude = ["tests"]
 
 [features]
-default = []
+_manual-tls = ["payjoin/_manual-tls"]
+_test-utils = ["payjoin-test-utils", "tokio"]
 csharp = ["dep:uniffi-bindgen-cs"]
 dart = ["dep:uniffi-dart"]
-_test-utils = ["payjoin-test-utils", "tokio"]
-_manual-tls = ["payjoin/_manual-tls"]
+default = []
 wasm_js = ["getrandom/js"]
 
 [lib]
-name = "payjoin_ffi"
 crate-type = ["lib", "staticlib", "cdylib"]
+name = "payjoin_ffi"
 
 [[bin]]
 name = "uniffi-bindgen"

--- a/payjoin-ffi/dart/native/Cargo.toml
+++ b/payjoin-ffi/dart/native/Cargo.toml
@@ -1,19 +1,19 @@
 [workspace]
 
 [package]
-name = "payjoin-ffi-wrapper"
 description = "This is a simple wrapper crate which re-exports payjoin-ffi for publishing to pub.dev"
-version = "0.1.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
+name = "payjoin-ffi-wrapper"
 publish = false
+version = "0.1.0"
 
 [features]
 _test-utils = ["payjoin-ffi/_test-utils"]
 
 [lib]
-name = "payjoin_ffi_wrapper"
 crate-type = ["staticlib", "cdylib"]
+name = "payjoin_ffi_wrapper"
 
 [dependencies]
 payjoin-ffi = { git = "https://github.com/payjoin/rust-payjoin.git", branch = "master", features = [

--- a/payjoin-ffi/javascript/test-utils/Cargo.toml
+++ b/payjoin-ffi/javascript/test-utils/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
+edition = "2021"
 name = "payjoin-test-utils-napi"
 version = "0.1.0"
-edition = "2021"
 
 [lib]
 crate-type = ["cdylib"]

--- a/payjoin-mailroom/Cargo.toml
+++ b/payjoin-mailroom/Cargo.toml
@@ -1,28 +1,28 @@
 [package]
-name = "payjoin-mailroom"
-version = "0.1.0"
-description = "Combined Payjoin Directory and OHTTP Relay"
-repository = "https://github.com/payjoin/rust-payjoin/tree/master/payjoin-mailroom"
-keywords = ["bip77", "bitcoin", "ohttp", "payjoin", "privacy"]
 categories = [
   "cryptography::cryptocurrencies",
   "network-programming",
   "web-programming",
 ]
-license = "MITNFA"
+description = "Combined Payjoin Directory and OHTTP Relay"
 edition = "2021"
+keywords = ["bip77", "bitcoin", "ohttp", "payjoin", "privacy"]
+license = "MITNFA"
+name = "payjoin-mailroom"
+repository = "https://github.com/payjoin/rust-payjoin/tree/master/payjoin-mailroom"
 rust-version = "1.85.0"
+version = "0.1.0"
 
 [features]
-default = []
 _manual-tls = ["dep:axum-server", "dep:rustls", "ohttp-relay/_test-util"]
+access-control = ["dep:flate2", "dep:ipnet", "dep:maxminddb", "dep:reqwest"]
 acme = [
   "dep:tokio-rustls-acme",
   "dep:axum-server",
   "dep:rustls",
   "dep:tokio-stream",
 ]
-access-control = ["dep:flate2", "dep:ipnet", "dep:maxminddb", "dep:reqwest"]
+default = []
 telemetry = ["dep:opentelemetry-otlp"]
 
 [dependencies]

--- a/payjoin-test-utils/Cargo.toml
+++ b/payjoin-test-utils/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "payjoin-test-utils"
-version = "0.0.1"
-edition = "2021"
 authors = ["Dan Gould <d@ngould.dev>"]
 description = "Payjoin test utilities"
+edition = "2021"
+license = "MIT"
+name = "payjoin-test-utils"
 repository = "https://github.com/payjoin/rust-payjoin"
 rust-version = "1.85"
-license = "MIT"
+version = "0.0.1"
 
 [dependencies]
 axum-server = { version = "0.8", features = ["tls-rustls-no-provider"] }

--- a/payjoin/Cargo.toml
+++ b/payjoin/Cargo.toml
@@ -1,21 +1,21 @@
 [package]
-name = "payjoin"
-version = "1.0.0-rc.2"
 authors = ["Dan Gould <d@ngould.dev>"]
-description = "Payjoin Library implementing BIP 78 and BIP 77 batching protocols."
-repository = "https://github.com/payjoin/rust-payjoin"
-readme = "../README.md"
-keywords = ["bip78", "payjoin", "bitcoin"]
 categories = [
   "api-bindings",
   "cryptography::cryptocurrencies",
   "network-programming",
 ]
-license = "MITNFA"
-resolver = "2"
+description = "Payjoin Library implementing BIP 78 and BIP 77 batching protocols."
 edition = "2021"
-rust-version = "1.85"
 exclude = ["tests"]
+keywords = ["bip78", "payjoin", "bitcoin"]
+license = "MITNFA"
+name = "payjoin"
+readme = "../README.md"
+repository = "https://github.com/payjoin/rust-payjoin"
+resolver = "2"
+rust-version = "1.85"
+version = "1.0.0-rc.2"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -35,9 +35,9 @@ directory = []
 v1 = ["_core"]
 v2 = ["_core", "hpke", "bhttp", "ohttp", "directory"]
 #[doc = "Functions to fetch OHTTP keys via CONNECT proxy using reqwest. Enables `v2` since only `v2` uses OHTTP."]
-io = ["v2", "reqwest/rustls-tls"]
 _manual-tls = ["reqwest/rustls-tls", "rustls"]
 _test-utils = []
+io = ["v2", "reqwest/rustls-tls"]
 
 [dependencies]
 bhttp = { version = "0.6.1", optional = true }

--- a/taplo.toml
+++ b/taplo.toml
@@ -7,7 +7,18 @@ indent_size = 2
 
 [[rule]]
 include = ["**/Cargo.toml"]
-keys = ["dependencies", "*-dependencies", "workspace"]
+keys = [
+  "dependencies",
+  "dev-dependencies",
+  "build-dependencies",
+  "workspace.dependencies",
+]
 [rule.formatting]
 reorder_keys = true
 align_comments = true
+
+[[rule]]
+include = ["**/Cargo.toml"]
+keys = ["package", "features", "lib", "package.metadata", "package.metadata.*"]
+[rule.formatting]
+reorder_keys = true


### PR DESCRIPTION
## Summary

- Extended `taplo.toml` to reorder keys in `[package]`, `[features]`, `[lib]`, and `[package.metadata]` sections
- Ran `taplo fmt` across all 11 `Cargo.toml` files for consistent formatting

Closes #1016

## Open questions

- Should taplo be added to the nix devshell?
- Should CI enforce `taplo fmt --check`?

## Test plan

- [ ] `nix fmt -- --ci` passes
- [ ] `cargo clippy --all-targets --keep-going --all-features -- -D warnings` clean
- [ ] `codespell` clean
- [ ] `taplo fmt --check` passes
- [ ] CI passes on fork

Disclosure: co-authored by Claude