### PR TITLE
Remove stale incompatible_msrv suppressions

### DIFF
--- a/payjoin-cli/src/app/v1.rs
+++ b/payjoin-cli/src/app/v1.rs
@@ -95,7 +95,6 @@ impl AppTrait for App {
         Ok(())
     }
 
-    #[allow(clippy::incompatible_msrv)]
     async fn receive_payjoin(&self, amount: Amount) -> Result<()> {
         let mut interrupt = self.interrupt.clone();
         tokio::select! {

--- a/payjoin-cli/src/app/v2/mod.rs
+++ b/payjoin-cli/src/app/v2/mod.rs
@@ -153,7 +153,6 @@ impl AppTrait for App {
 
     fn wallet(&self) -> BitcoindWallet { self.wallet.clone() }
 
-    #[allow(clippy::incompatible_msrv)]
     async fn send_payjoin(&self, bip21: &str, fee_rate: FeeRate) -> Result<()> {
         use payjoin::UriExt;
         let uri = Uri::try_from(bip21)
@@ -276,7 +275,6 @@ impl AppTrait for App {
         Ok(())
     }
 
-    #[allow(clippy::incompatible_msrv)]
     async fn resume_payjoins(&self) -> Result<()> {
         let recv_session_ids = self.db.get_recv_session_ids()?;
         let send_session_ids = self.db.get_send_session_ids()?;
@@ -608,7 +606,6 @@ impl App {
         res
     }
 
-    #[allow(clippy::incompatible_msrv)]
     async fn read_from_directory(
         &self,
         session: Receiver<Initialized>,


### PR DESCRIPTION
## Summary

- Removed 4 `#[allow(clippy::incompatible_msrv)]` attributes from `payjoin-cli` that are no longer needed

Closes #794

## Test plan

- [ ] `nix fmt -- --ci` passes
- [ ] `cargo clippy --all-targets --keep-going --all-features -- -D warnings` clean
- [ ] `codespell` clean
- [ ] CI passes on fork

Disclosure: co-authored by Claude