### PR TITLE
Add CodeRabbit config for AI-powered API review

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,61 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: en-US
+reviews:
+  profile: "chill"
+  high_level_summary: false
+  changed_files_summary: false
+  sequence_diagrams: false
+  estimate_code_review_effort: false
+  suggested_labels: false
+  suggested_reviewers: false
+  path_instructions:
+    - path: "payjoin/src/**/*.rs"
+      instructions: |
+        Check for these Rust API guideline violations:
+
+        C-CALLER-CONTROL (critical): Flag any pub fn taking &T, &str,
+        or &[u8] that internally clones, copies, or calls .to_owned()
+        / .to_string() / .to_vec() on the parameter. The fix is to
+        take T, String, or Vec<u8> by value and let the caller decide
+        whether to clone or move.
+
+        Also check the Rust API guidelines checklist:
+        - C-COMMON-TRAITS: pub types should impl Send, Sync, Debug,
+          Display, Default, serde traits where appropriate
+        - C-CONV: use From/Into and AsRef for conversions rather than
+          ad-hoc methods
+        - C-GETTER: prefer foo() / set_foo() naming for getters and
+          setters, not get_foo()
+        - C-ITER: collections should impl IntoIterator and expose
+          iter(), iter_mut() where appropriate
+        - C-SERDE: pub types should impl Serialize/Deserialize when
+          they represent data that crosses process boundaries
+        - C-SEND-SYNC: err on the side of Send + Sync for pub types
+          unless there is a specific reason not to
+
+        If no violations are found, say "No findings." Do not invent
+        issues. Format: file:line - pattern - suggested fix.
+    - path: "payjoin-cli/src/**/*.rs"
+      instructions: |
+        Check for these Rust API guideline violations:
+
+        C-CALLER-CONTROL (critical): Flag any pub fn taking &T, &str,
+        or &[u8] that internally clones, copies, or calls .to_owned()
+        / .to_string() / .to_vec() on the parameter. The fix is to
+        take T, String, or Vec<u8> by value and let the caller decide
+        whether to clone or move.
+
+        Also check the Rust API guidelines checklist:
+        - C-COMMON-TRAITS: pub types should impl Send, Sync, Debug,
+          Display, Default, serde traits where appropriate
+        - C-CONV: use From/Into and AsRef for conversions rather than
+          ad-hoc methods
+        - C-GETTER: prefer foo() / set_foo() naming for getters and
+          setters, not get_foo()
+        - C-ITER: collections should impl IntoIterator and expose
+          iter(), iter_mut() where appropriate
+        - C-SEND-SYNC: err on the side of Send + Sync for pub types
+          unless there is a specific reason not to
+
+        If no violations are found, say "No findings." Do not invent
+        issues. Format: file:line - pattern - suggested fix.


### PR DESCRIPTION
## Summary

Issue #1374 asks for automated API review to catch Rust API guideline violations (especially C-CALLER-CONTROL: pub fns that take `&T` but secretly clone) before they reach human reviewers. Manual review for these patterns is tedious and easy to miss across a growing codebase. CodeRabbit provides free, AI-powered PR review that can be scoped to specific paths and trained on project-specific rules.

Closes #1374

## Approach

Add a `.coderabbit.yaml` configured with the "chill" profile so reviews are advisory-only and never block CI. Noisy features (walk-through summaries, sequence diagrams, auto-labels, auto-reviewer assignment) are all disabled to keep signal-to-noise high. Path-scoped instructions target `payjoin/src/**/*.rs` and `payjoin-cli/src/**/*.rs` with the C-CALLER-CONTROL rule and a broader Rust API guidelines checklist (C-COMMON-TRAITS, C-CONV, C-GETTER, C-ITER, C-SERDE, C-SEND-SYNC). C-SERDE is included for `payjoin/src/` but omitted from `payjoin-cli/src/` since CLI types are less likely to need serde.

## Open questions

- CodeRabbit's general reviewer still runs alongside path instructions; if it proves too noisy the maintainer may need to tune further or consider the claude-code-action alternative mentioned in the issue.

Disclosure: co-authored by Claude
