### PR TITLE
Expose PSBT input error index in FFI

### DIFF
--- a/payjoin-ffi/src/send/error.rs
+++ b/payjoin-ffi/src/send/error.rs
@@ -8,18 +8,36 @@ use crate::error::{FfiValidationError, ImplementationError};
 /// Error building a Sender from a SenderBuilder.
 ///
 /// This error is unrecoverable.
+///
+/// When the error is caused by an invalid original PSBT input, the
+/// [`input_index`](BuildSenderError::input_index) method returns the
+/// zero-based position of the offending input so that FFI consumers can
+/// surface precise diagnostics.
 #[derive(Debug, PartialEq, Eq, thiserror::Error, uniffi::Object)]
 #[error("Error initializing the sender: {msg}")]
 pub struct BuildSenderError {
     msg: String,
+    input_index: Option<u64>,
+}
+
+#[uniffi::export]
+impl BuildSenderError {
+    /// Returns the zero-based index of the PSBT input that failed
+    /// validation, if this error was caused by an invalid original input.
+    pub fn input_index(&self) -> Option<u64> { self.input_index }
 }
 
 impl From<PsbtParseError> for BuildSenderError {
-    fn from(value: PsbtParseError) -> Self { BuildSenderError { msg: value.to_string() } }
+    fn from(value: PsbtParseError) -> Self {
+        BuildSenderError { msg: value.to_string(), input_index: None }
+    }
 }
 
 impl From<send::BuildSenderError> for BuildSenderError {
-    fn from(value: send::BuildSenderError) -> Self { BuildSenderError { msg: value.to_string() } }
+    fn from(value: send::BuildSenderError) -> Self {
+        let input_index = value.input_index().map(|i| i as u64);
+        BuildSenderError { msg: value.to_string(), input_index }
+    }
 }
 
 /// FFI-visible PSBT parsing error surfaced at the sender boundary.
@@ -193,5 +211,33 @@ where
             return SenderPersistedError::BuildSenderError(Arc::new(api_err.into()));
         }
         SenderPersistedError::Unexpected
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ffi_build_sender_error_with_input_index() {
+        let err = BuildSenderError { msg: "invalid PSBT input #5".into(), input_index: Some(5) };
+        assert_eq!(err.input_index(), Some(5));
+        assert!(err.to_string().contains("#5"));
+    }
+
+    #[test]
+    fn ffi_build_sender_error_without_input_index() {
+        let err = BuildSenderError {
+            msg: "the original transaction has no inputs".into(),
+            input_index: None,
+        };
+        assert_eq!(err.input_index(), None);
+    }
+
+    #[test]
+    fn ffi_build_sender_error_from_psbt_parse_error() {
+        let parse_err = PsbtParseError::InvalidPsbt("bad psbt".into());
+        let err = BuildSenderError::from(parse_err);
+        assert_eq!(err.input_index(), None);
     }
 }

--- a/payjoin/src/core/psbt/mod.rs
+++ b/payjoin/src/core/psbt/mod.rs
@@ -353,6 +353,16 @@ impl fmt::Display for PsbtInputsError {
     }
 }
 
+impl PsbtInputsError {
+    /// Returns the index of the PSBT input that failed validation.
+    pub fn index(&self) -> usize { self.index }
+
+    #[cfg(test)]
+    pub(crate) fn new_test(index: usize, error: InternalPsbtInputError) -> Self {
+        Self { index, error }
+    }
+}
+
 impl std::error::Error for PsbtInputsError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.error) }
 }
@@ -430,7 +440,10 @@ mod test {
     use bitcoin::{Psbt, ScriptBuf, Transaction};
     use payjoin_test_utils::PARSED_ORIGINAL_PSBT;
 
-    use crate::psbt::{InputWeightError, InternalInputPair, InternalPsbtInputError, PsbtExt};
+    use crate::psbt::{
+        InputWeightError, InternalInputPair, InternalPsbtInputError, PrevTxOutError, PsbtExt,
+        PsbtInputsError,
+    };
 
     #[test]
     fn validate_input_utxos() {
@@ -540,5 +553,15 @@ mod test {
         let pair: InternalInputPair = InternalInputPair { txin, psbtin: &psbtin };
         let weight = pair.expected_input_weight();
         assert_eq!(weight.unwrap_err(), InputWeightError::NoRedeemScript)
+    }
+
+    #[test]
+    fn psbt_inputs_error_exposes_index() {
+        let error = PsbtInputsError {
+            index: 7,
+            error: InternalPsbtInputError::PrevTxOut(PrevTxOutError::MissingUtxoInformation),
+        };
+        assert_eq!(error.index(), 7);
+        assert!(error.to_string().contains("#7"));
     }
 }

--- a/payjoin/src/core/send/error.rs
+++ b/payjoin/src/core/send/error.rs
@@ -30,6 +30,17 @@ pub(crate) enum InternalBuildSenderError {
     AddressType(crate::psbt::AddressTypeError),
 }
 
+impl BuildSenderError {
+    /// Returns the index of the invalid PSBT input, if this error was
+    /// caused by an invalid original input.
+    pub fn input_index(&self) -> Option<usize> {
+        match &self.0 {
+            InternalBuildSenderError::InvalidOriginalInput(e) => Some(e.index()),
+            _ => None,
+        }
+    }
+}
+
 impl From<InternalBuildSenderError> for BuildSenderError {
     fn from(value: InternalBuildSenderError) -> Self { BuildSenderError(value) }
 }
@@ -434,5 +445,23 @@ mod tests {
             ResponseError::from_json(invalid_json_error),
             ResponseError::Validation(_)
         ));
+    }
+
+    #[test]
+    fn build_sender_error_exposes_input_index() {
+        use crate::psbt::{InternalPsbtInputError, PrevTxOutError, PsbtInputsError};
+
+        let psbt_err = PsbtInputsError::new_test(
+            3,
+            InternalPsbtInputError::PrevTxOut(PrevTxOutError::MissingUtxoInformation),
+        );
+        let err = BuildSenderError::from(InternalBuildSenderError::InvalidOriginalInput(psbt_err));
+        assert_eq!(err.input_index(), Some(3));
+    }
+
+    #[test]
+    fn build_sender_error_no_index_for_other_variants() {
+        let err = BuildSenderError::from(InternalBuildSenderError::NoInputs);
+        assert_eq!(err.input_index(), None);
     }
 }


### PR DESCRIPTION
## Summary

When a PSBT input fails validation, FFI consumers currently get an error message but no way to programmatically identify *which* input caused the failure. Without the index, callers must parse error strings or guess, making robust error handling impossible in language bindings (Swift, Kotlin, Python).

Closes #1276

## Approach

Add an `index()` getter to the core `PsbtInputsError` and an `input_index()` getter to `BuildSenderError`, then thread the index through the FFI layer as `input_index: Option<u64>` on `BuildSenderError`, populated during the `From<send::BuildSenderError>` conversion. The receive-side `PsbtInputError` (singular, not plural) already represents a single input and has no index to propagate, so it is left unchanged. Six tests verify index propagation at the core psbt, core send, and FFI layers.

## Open questions

None

Disclosure: co-authored by Claude
