### PR TITLE
Rename EncapsulationError to DecapsulationError

### DIFF
--- a/payjoin-ffi/src/send/error.rs
+++ b/payjoin-ffi/src/send/error.rs
@@ -61,7 +61,7 @@ pub struct CreateRequestError(#[from] send::v2::CreateRequestError);
 /// Error returned for v2-specific payload encapsulation errors.
 #[derive(Debug, thiserror::Error, uniffi::Object)]
 #[error(transparent)]
-pub struct EncapsulationError(#[from] send::v2::EncapsulationError);
+pub struct DecapsulationError(#[from] send::v2::DecapsulationError);
 
 /// Error that may occur when the response from receiver is malformed.
 #[derive(Debug, thiserror::Error, uniffi::Object)]
@@ -122,7 +122,7 @@ pub struct SenderReplayError(
 pub enum SenderPersistedError {
     /// rust-payjoin sender Encapsulation error
     #[error(transparent)]
-    EncapsulationError(Arc<EncapsulationError>),
+    DecapsulationError(Arc<DecapsulationError>),
     /// rust-payjoin sender response error
     #[error(transparent)]
     ResponseError(ResponseError),
@@ -141,12 +141,12 @@ impl From<ImplementationError> for SenderPersistedError {
     fn from(value: ImplementationError) -> Self { SenderPersistedError::Storage(Arc::new(value)) }
 }
 
-impl<S> From<payjoin::persist::PersistedError<send::v2::EncapsulationError, S>>
+impl<S> From<payjoin::persist::PersistedError<send::v2::DecapsulationError, S>>
     for SenderPersistedError
 where
     S: std::error::Error + Send + Sync + 'static,
 {
-    fn from(err: payjoin::persist::PersistedError<send::v2::EncapsulationError, S>) -> Self {
+    fn from(err: payjoin::persist::PersistedError<send::v2::DecapsulationError, S>) -> Self {
         if err.storage_error_ref().is_some() {
             if let Some(storage_err) = err.storage_error() {
                 return SenderPersistedError::from(ImplementationError::new(storage_err));
@@ -154,7 +154,7 @@ where
             return SenderPersistedError::Unexpected;
         }
         if let Some(api_err) = err.api_error() {
-            return SenderPersistedError::EncapsulationError(Arc::new(api_err.into()));
+            return SenderPersistedError::DecapsulationError(Arc::new(api_err.into()));
         }
         SenderPersistedError::Unexpected
     }

--- a/payjoin-ffi/src/send/mod.rs
+++ b/payjoin-ffi/src/send/mod.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 use std::sync::{Arc, RwLock};
 
 pub use error::{
-    BuildSenderError, CreateRequestError, EncapsulationError, PsbtParseError, ResponseError,
+    BuildSenderError, CreateRequestError, DecapsulationError, PsbtParseError, ResponseError,
     SenderInputError,
 };
 
@@ -386,7 +386,7 @@ pub struct WithReplyKeyTransition(
                 payjoin::persist::MaybeFatalTransition<
                     payjoin::send::v2::SessionEvent,
                     payjoin::send::v2::Sender<payjoin::send::v2::PollingForProposal>,
-                    payjoin::send::v2::EncapsulationError,
+                    payjoin::send::v2::DecapsulationError,
                 >,
             >,
         >,

--- a/payjoin/src/core/send/error.rs
+++ b/payjoin/src/core/send/error.rs
@@ -98,7 +98,7 @@ pub(crate) enum InternalValidationError {
     ContentTooLarge,
     Proposal(InternalProposalError),
     #[cfg(feature = "v2")]
-    V2Encapsulation(crate::send::v2::EncapsulationError),
+    V2Decapsulation(crate::send::v2::DecapsulationError),
 }
 
 impl From<InternalValidationError> for ValidationError {
@@ -126,7 +126,7 @@ impl fmt::Display for ValidationError {
             }
             Proposal(e) => write!(f, "proposal PSBT error: {e}"),
             #[cfg(feature = "v2")]
-            V2Encapsulation(e) => write!(f, "v2 encapsulation error: {e}"),
+            V2Decapsulation(e) => write!(f, "v2 decapsulation error: {e}"),
         }
     }
 }
@@ -141,7 +141,7 @@ impl std::error::Error for ValidationError {
             ContentTooLarge => None,
             Proposal(e) => Some(e),
             #[cfg(feature = "v2")]
-            V2Encapsulation(e) => Some(e),
+            V2Decapsulation(e) => Some(e),
         }
     }
 }

--- a/payjoin/src/core/send/v2/error.rs
+++ b/payjoin/src/core/send/v2/error.rs
@@ -55,21 +55,24 @@ impl From<crate::into_url::Error> for CreateRequestError {
     }
 }
 
-/// Error returned for v2-specific payload encapsulation errors.
+/// Error returned for v2-specific payload decapsulation errors.
+///
+/// This error is raised when decapsulating responses from the directory,
+/// not during request encapsulation (which produces [`CreateRequestError`]).
 #[derive(Debug)]
-pub struct EncapsulationError(InternalEncapsulationError);
+pub struct DecapsulationError(InternalDecapsulationError);
 
 #[derive(Debug)]
-pub(crate) enum InternalEncapsulationError {
+pub(crate) enum InternalDecapsulationError {
     /// The HPKE failed.
     Hpke(crate::hpke::HpkeError),
     /// The directory returned a bad response
     DirectoryResponse(DirectoryResponseError),
 }
 
-impl fmt::Display for EncapsulationError {
+impl fmt::Display for DecapsulationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use InternalEncapsulationError::*;
+        use InternalDecapsulationError::*;
 
         match &self.0 {
             Hpke(error) => write!(f, "HPKE error: {error}"),
@@ -78,9 +81,9 @@ impl fmt::Display for EncapsulationError {
     }
 }
 
-impl std::error::Error for EncapsulationError {
+impl std::error::Error for DecapsulationError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        use InternalEncapsulationError::*;
+        use InternalDecapsulationError::*;
 
         match &self.0 {
             Hpke(error) => Some(error),
@@ -89,12 +92,12 @@ impl std::error::Error for EncapsulationError {
     }
 }
 
-impl From<InternalEncapsulationError> for EncapsulationError {
-    fn from(value: InternalEncapsulationError) -> Self { EncapsulationError(value) }
+impl From<InternalDecapsulationError> for DecapsulationError {
+    fn from(value: InternalDecapsulationError) -> Self { DecapsulationError(value) }
 }
 
-impl From<InternalEncapsulationError> for super::ResponseError {
-    fn from(value: InternalEncapsulationError) -> Self {
-        super::InternalValidationError::V2Encapsulation(value.into()).into()
+impl From<InternalDecapsulationError> for super::ResponseError {
+    fn from(value: InternalDecapsulationError) -> Self {
+        super::InternalValidationError::V2Decapsulation(value.into()).into()
     }
 }

--- a/payjoin/src/core/send/v2/mod.rs
+++ b/payjoin/src/core/send/v2/mod.rs
@@ -30,8 +30,8 @@
 
 use bitcoin::hashes::{sha256, Hash};
 use bitcoin::Address;
-pub use error::{CreateRequestError, EncapsulationError};
-use error::{InternalCreateRequestError, InternalEncapsulationError};
+pub use error::{CreateRequestError, DecapsulationError};
+use error::{InternalCreateRequestError, InternalDecapsulationError};
 use ohttp::ClientResponse;
 use serde::{Deserialize, Serialize};
 pub use session::{
@@ -342,18 +342,18 @@ impl Sender<WithReplyKey> {
         self,
         response: &[u8],
         post_ctx: ClientResponse,
-    ) -> MaybeFatalTransition<SessionEvent, Sender<PollingForProposal>, EncapsulationError> {
+    ) -> MaybeFatalTransition<SessionEvent, Sender<PollingForProposal>, DecapsulationError> {
         match process_post_res(response, post_ctx) {
             Ok(()) => {}
             Err(e) =>
                 if e.is_fatal() {
                     return MaybeFatalTransition::fatal(
                         SessionEvent::Closed(SessionOutcome::Failure),
-                        InternalEncapsulationError::DirectoryResponse(e).into(),
+                        InternalDecapsulationError::DirectoryResponse(e).into(),
                     );
                 } else {
                     return MaybeFatalTransition::transient(
-                        InternalEncapsulationError::DirectoryResponse(e).into(),
+                        InternalDecapsulationError::DirectoryResponse(e).into(),
                     );
                 },
         }
@@ -483,11 +483,11 @@ impl Sender<PollingForProposal> {
                 if e.is_fatal() {
                     return MaybeSuccessTransitionWithNoResults::fatal(
                         SessionEvent::Closed(SessionOutcome::Failure),
-                        InternalEncapsulationError::DirectoryResponse(e).into(),
+                        InternalDecapsulationError::DirectoryResponse(e).into(),
                     );
                 } else {
                     return MaybeSuccessTransitionWithNoResults::transient(
-                        InternalEncapsulationError::DirectoryResponse(e).into(),
+                        InternalDecapsulationError::DirectoryResponse(e).into(),
                     );
                 },
         };
@@ -501,7 +501,7 @@ impl Sender<PollingForProposal> {
             Err(e) =>
                 return MaybeSuccessTransitionWithNoResults::fatal(
                     SessionEvent::Closed(SessionOutcome::Failure),
-                    InternalEncapsulationError::Hpke(e).into(),
+                    InternalDecapsulationError::Hpke(e).into(),
                 ),
         };
 


### PR DESCRIPTION
# Audit and rename error types for issue #749

## Summary

- Rename `EncapsulationError` to `DecapsulationError` (and internal types)
- Document duplication and naming issues across `SessionError`,
  `CreateRequestError`, and the former `EncapsulationError`

## What changed

`EncapsulationError` was a misnomer: it is exclusively raised when
_decapsulating_ responses (`process_response`), never during request
_encapsulation_ (`create_v2_post_request` / `create_poll_request`, which
produce `CreateRequestError`). Renamed to `DecapsulationError` throughout
core and FFI crates, including the `InternalValidationError::V2Encapsulation`
variant (now `V2Decapsulation`).

## Audit findings

### Error type inventory

| Type                                                            | Location   | Variants                                                                 |
| --------------------------------------------------------------- | ---------- | ------------------------------------------------------------------------ |
| `InternalCreateRequestError`                                    | send v2    | `Url`, `Hpke`, `OhttpEncapsulation`, `Expired`                           |
| `InternalDecapsulationError` (was `InternalEncapsulationError`) | send v2    | `Hpke`, `DirectoryResponse`                                              |
| `InternalSessionError`                                          | receive v2 | `ParseUrl`, `Expired`, `OhttpEncapsulation`, `Hpke`, `DirectoryResponse` |

### Duplication between send and receive error types

`InternalSessionError` is a superset containing all variants from both
`InternalCreateRequestError` and `InternalDecapsulationError`:

| Variant            | CreateRequest | Decapsulation | Session  |
| ------------------ | :-----------: | :-----------: | :------: |
| Url / ParseUrl     |      Url      |       -       | ParseUrl |
| Hpke               |       x       |       x       |    x     |
| OhttpEncapsulation |       x       |       -       |    x     |
| Expired            |       x       |       -       |    x     |
| DirectoryResponse  |       -       |       x       |    x     |

### Issues requiring maintainer decisions

1. **Cross-side deduplication**: `InternalCreateRequestError` and
   `InternalSessionError` have nearly identical variant sets but serve
   different sides of the protocol (send vs receive). Collapsing them
   requires architectural decisions about shared error types.

2. **Decapsulation/Session subset**: `InternalDecapsulationError` is a
   strict subset of `InternalSessionError` (`Hpke` + `DirectoryResponse`).
   Could potentially reuse a shared type.

3. **Inconsistent variant naming**: `Url` (send) vs `ParseUrl` (receive)
   for the same semantic concept (`into_url::Error`).

4. **Hpke variant placement**: The `Hpke` variant in `DecapsulationError`
   represents HPKE decryption (a distinct crypto operation from OHTTP
   decapsulation). May belong at a different level.

5. **process_response return type asymmetry**: Send POST returns
   `DecapsulationError`, send GET returns `ResponseError`. The asymmetry
   may be intentional (POST only confirms acceptance; GET retrieves and
   validates a full proposal).

## Test plan

- [x] `cargo clippy --all-targets --keep-going --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `codespell`
- [x] `nix fmt -- --ci`

Disclosure: co-authored by Claude
