### PR TITLE
Unify short_id_from_pubkey as HpkePublicKey method

### DIFF
--- a/payjoin/src/core/hpke.rs
+++ b/payjoin/src/core/hpke.rs
@@ -2,6 +2,7 @@ use core::fmt;
 use std::error;
 use std::ops::Deref;
 
+use bitcoin::hashes::{sha256, Hash};
 use bitcoin::key::constants::{ELLSWIFT_ENCODING_SIZE, PUBLIC_KEY_SIZE};
 use bitcoin::secp256k1;
 use bitcoin::secp256k1::ellswift::ElligatorSwift;
@@ -11,6 +12,8 @@ use hpke::kem::SecpK256HkdfSha256;
 use hpke::rand_core::OsRng;
 use hpke::{Deserializable, OpModeR, OpModeS, Serializable};
 use serde::{Deserialize, Serialize};
+
+use crate::directory::ShortId;
 
 pub const PADDED_MESSAGE_BYTES: usize = 7168;
 pub const PADDED_PLAINTEXT_A_LENGTH: usize =
@@ -133,6 +136,9 @@ impl HpkePublicKey {
             compressed_key.serialize_uncompressed().as_slice(),
         )?))
     }
+
+    /// Derive the [`ShortId`] mailbox identifier for this public key.
+    pub fn short_id(&self) -> ShortId { sha256::Hash::hash(&self.to_compressed_bytes()).into() }
 }
 
 impl Deref for HpkePublicKey {

--- a/payjoin/src/core/receive/v2/mod.rs
+++ b/payjoin/src/core/receive/v2/mod.rs
@@ -28,7 +28,6 @@ use std::str::FromStr;
 #[cfg(not(target_arch = "wasm32"))]
 use std::time::Duration;
 
-use bitcoin::hashes::{sha256, Hash};
 use bitcoin::psbt::Psbt;
 use bitcoin::{Address, Amount, FeeRate, OutPoint, Script, TxOut, Txid};
 pub(crate) use error::InternalSessionError;
@@ -98,7 +97,7 @@ impl SessionContext {
 
     /// The mailbox ID where the receiver expects the sender's Original PSBT.
     pub(crate) fn proposal_mailbox_id(&self) -> ShortId {
-        short_id_from_pubkey(self.receiver_key.public_key())
+        self.receiver_key.public_key().short_id()
     }
 
     /// The mailbox ID where replies (the Proposal PSBT or errors) should
@@ -109,7 +108,7 @@ impl SessionContext {
     // v2 or v1 sender anyway. Ideally this should be impossible leveraging the
     // typestate machinery
     pub(crate) fn reply_mailbox_id(&self) -> ShortId {
-        short_id_from_pubkey(self.reply_key.as_ref().unwrap_or(self.receiver_key.public_key()))
+        self.reply_key.as_ref().unwrap_or(self.receiver_key.public_key()).short_id()
     }
 }
 
@@ -120,10 +119,6 @@ where
     let s = String::deserialize(deserializer)?;
     let address = Address::from_str(&s).map_err(serde::de::Error::custom)?;
     Ok(address.assume_checked())
-}
-
-fn short_id_from_pubkey(pubkey: &HpkePublicKey) -> ShortId {
-    sha256::Hash::hash(&pubkey.to_compressed_bytes()).into()
 }
 
 /// Represents the various states of a Payjoin receiver session during the protocol flow.
@@ -1100,15 +1095,14 @@ impl Receiver<PayjoinProposal> {
         if let Some(e) = &self.session_context.reply_key {
             // Prepare v2 payload
             let payjoin_bytes = self.psbt().serialize();
-            let sender_mailbox = short_id_from_pubkey(e);
+            let sender_mailbox = e.short_id();
             target_resource = mailbox_endpoint(&self.session_context.directory, &sender_mailbox);
             body = encrypt_message_b(payjoin_bytes, &self.session_context.receiver_key, e)?;
             method = "POST";
         } else {
             // Prepare v2 wrapped and backwards-compatible v1 payload
             body = self.psbt().to_string().as_bytes().to_vec();
-            let receiver_mailbox =
-                short_id_from_pubkey(self.session_context.receiver_key.public_key());
+            let receiver_mailbox = self.session_context.receiver_key.public_key().short_id();
             target_resource = mailbox_endpoint(&self.session_context.directory, &receiver_mailbox);
             method = "PUT";
         }

--- a/payjoin/src/core/send/v2/mod.rs
+++ b/payjoin/src/core/send/v2/mod.rs
@@ -28,7 +28,6 @@
 //! Note: Even fresh requests may be linkable via metadata (e.g. client IP, request timing),
 //! but request reuse makes correlation trivial for the relay.
 
-use bitcoin::hashes::{sha256, Hash};
 use bitcoin::Address;
 pub use error::{CreateRequestError, EncapsulationError};
 use error::{InternalCreateRequestError, InternalEncapsulationError};
@@ -49,7 +48,6 @@ use crate::persist::{
     MaybeFatalTransition, MaybeSuccessTransitionWithNoResults, NextStateTransition,
 };
 use crate::uri::v2::PjParam;
-use crate::uri::ShortId;
 use crate::{HpkeKeyPair, IntoUrl, PjUri, Request};
 
 mod error;
@@ -432,13 +430,8 @@ impl Sender<PollingForProposal> {
         &self,
         ohttp_relay: impl IntoUrl,
     ) -> Result<(Request, ohttp::ClientResponse), CreateRequestError> {
-        // TODO unify with receiver's fn short_id_from_pubkey
-        let hash = sha256::Hash::hash(
-            &HpkeKeyPair::from_secret_key(&self.session_context.reply_key)
-                .public_key()
-                .to_compressed_bytes(),
-        );
-        let mailbox: ShortId = hash.into();
+        let mailbox =
+            HpkeKeyPair::from_secret_key(&self.session_context.reply_key).public_key().short_id();
         let url = Url::parse(self.session_context.pj_param.endpoint().as_str())
             .expect("Could not parse url")
             .join(&mailbox.to_string())


### PR DESCRIPTION
## Summary

The `short_id_from_pubkey` helper was duplicated between `send/v2` and `receive/v2`, with a TODO comment asking for unification. Duplicate logic is a maintenance hazard: if the short-ID derivation ever changes, two call sites need updating in lockstep or they silently diverge.

Resolves TODO

## Approach

Extract the shared logic into an `HpkePublicKey::short_id()` method in `hpke.rs`, the natural home since the computation is purely a function of the public key. Both `send/v2` and `receive/v2` now call this single method. No behavioral change -- the derivation is identical, just owned in one place.

## Open questions

None

Disclosure: co-authored by Claude
