### PR TITLE
Document typestate Clone and ownership invariants

### DIFF
--- a/payjoin/src/core/receive/common/mod.rs
+++ b/payjoin/src/core/receive/common/mod.rs
@@ -1,6 +1,15 @@
 //! Common typestates and methods for both BIP 77 v2 and BIP 78 v1.
 //! This module isn't meant to be exposed publicly, but for v1 and v2
 //! APIs to expose as relevant typestates.
+//!
+//! # Typestate ownership
+//!
+//! Typestate transitions consume `self` so each state can only be used once.
+//! All typestate structs derive [`Clone`] because the v2 async protocol must
+//! serialize and deserialize state across session boundaries. Callers **must
+//! not** clone a value to reuse a prior state — doing so would bypass the
+//! intended state-machine ordering. See `AGENTS.md` § *Typestate Conventions*
+//! for the full policy.
 
 use std::cmp::{max, min};
 use std::collections::HashSet;

--- a/payjoin/src/core/receive/v1/mod.rs
+++ b/payjoin/src/core/receive/v1/mod.rs
@@ -7,7 +7,7 @@
 //! Each check method consumes `self` to enforce the transition order at
 //! compile time. [`Clone`] is derived for serialization/persistence only —
 //! callers **must not** clone to circumvent a state transition.
-//! See [`super::common`] and `AGENTS.md` § *Typestate Conventions*.
+//! See the `common` receive module and `AGENTS.md` § *Typestate Conventions*.
 //!
 //! Usage is pretty simple:
 //!

--- a/payjoin/src/core/receive/v1/mod.rs
+++ b/payjoin/src/core/receive/v1/mod.rs
@@ -1,6 +1,14 @@
 //! Receive BIP 78 Payjoin v1
 //!
 //! This module contains types and methods used to receive payjoin via BIP78.
+//!
+//! # Typestate ownership
+//!
+//! Each check method consumes `self` to enforce the transition order at
+//! compile time. [`Clone`] is derived for serialization/persistence only —
+//! callers **must not** clone to circumvent a state transition.
+//! See [`super::common`] and `AGENTS.md` § *Typestate Conventions*.
+//!
 //! Usage is pretty simple:
 //!
 //! 1. Generate a pj_uri [BIP 21](https://github.com/bitcoin/bips/blob/master/bip-0021.mediawiki)

--- a/payjoin/src/core/receive/v2/mod.rs
+++ b/payjoin/src/core/receive/v2/mod.rs
@@ -1,5 +1,13 @@
 //! Receive BIP 77 Payjoin v2
 //!
+//! # Typestate ownership
+//!
+//! Each check method consumes `self` to enforce the transition order at
+//! compile time. [`Clone`] is derived so state can be persisted across the
+//! async session boundary — callers **must not** clone to circumvent a
+//! state transition.
+//! See [`super::common`] and `AGENTS.md` § *Typestate Conventions*.
+//!
 //! This module contains the typestates and helper methods to perform a Payjoin v2 receive.
 //!
 //! Receiving Payjoin transactions securely and privately requires the receiver to run safety

--- a/payjoin/src/core/receive/v2/mod.rs
+++ b/payjoin/src/core/receive/v2/mod.rs
@@ -6,7 +6,7 @@
 //! compile time. [`Clone`] is derived so state can be persisted across the
 //! async session boundary — callers **must not** clone to circumvent a
 //! state transition.
-//! See [`super::common`] and `AGENTS.md` § *Typestate Conventions*.
+//! See the `common` receive module and `AGENTS.md` § *Typestate Conventions*.
 //!
 //! This module contains the typestates and helper methods to perform a Payjoin v2 receive.
 //!

--- a/payjoin/src/core/send/v1.rs
+++ b/payjoin/src/core/send/v1.rs
@@ -3,6 +3,13 @@
 //! This module contains types and methods used to implement sending via [BIP78
 //! Payjoin](https://github.com/bitcoin/bips/blob/master/bip-0078.mediawiki).
 //!
+//! # Typestate ownership
+//!
+//! Builder and context types consume `self` on state transitions.
+//! [`Clone`] is derived for serialization/persistence only — callers
+//! **must not** clone to circumvent a state transition.
+//! See `AGENTS.md` § *Typestate Conventions*.
+//!
 //! Usage is pretty simple:
 //!
 //! 1. Parse BIP21 as [`payjoin::Uri`](crate::Uri)

--- a/payjoin/src/core/send/v2/mod.rs
+++ b/payjoin/src/core/send/v2/mod.rs
@@ -1,5 +1,12 @@
 //! Send BIP 77 Payjoin v2
 //!
+//! # Typestate ownership
+//!
+//! Builder and context types consume `self` on state transitions.
+//! [`Clone`] is derived so state can be persisted across the async session
+//! boundary — callers **must not** clone to circumvent a state transition.
+//! See `AGENTS.md` § *Typestate Conventions*.
+//!
 //! This module contains types and methods used to implement sending via [BIP77
 //! Payjoin](https://github.com/bitcoin/bips/blob/master/bip-0077.md).
 //!


### PR DESCRIPTION
# Document typestate Clone and ownership invariants

Closes #402

## Summary

- Add `AGENTS.md` § *Typestate Conventions* with three contributor rules
  covering Clone derivation policy and ownership invariants.
- Add `# Typestate ownership` doc sections to all five typestate modules:
  `receive/common`, `receive/v1`, `receive/v2`, `send/v1`, `send/v2`.
- Fix private intra-doc links (`super::common`) that break `cargo doc`
  with `-D warnings`.

## Motivation

All 28 typestate structs derive `Clone`, which is intentional for
persistence/replay support in the v2 (BIP 77) protocol. Without
documentation, contributors might either (a) remove Clone assuming
it contradicts the consume-self pattern, or (b) clone values to
sidestep state transitions. The new docs make the policy explicit.

## Test plan

- `cargo fmt --all -- --check` — pass
- `cargo clippy --all-targets --keep-going --all-features -- -D warnings` — pass
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --document-private-items` — pass
- `codespell` — pass

Disclosure: co-authored by claude-code
