### PR TITLE
Specify nginx binary via NGINX_EXE env var

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,10 +31,9 @@ jobs:
         uses: DeterminateSystems/determinate-nix-action@main
       - name: "Use nix cache"
         uses: DeterminateSystems/magic-nix-cache-action@main
-      - name: "Add nginxWithStream to PATH"
+      - name: "Set NGINX_EXE for integration tests"
         run: |
-          # This is necessary for ohttp-relay integration tests
-          echo "$(nix build .#nginx-with-stream --print-out-paths --no-link)/bin" >> $GITHUB_PATH
+          echo "NGINX_EXE=$(nix build .#nginx-with-stream --print-out-paths --no-link)/bin/nginx" >> $GITHUB_ENV
       - name: "Use cache"
         uses: Swatinem/rust-cache@v2
       - name: Run tests
@@ -91,10 +90,9 @@ jobs:
         uses: DeterminateSystems/determinate-nix-action@main
       - name: "Use nix cache"
         uses: DeterminateSystems/magic-nix-cache-action@main
-      - name: "Add nginxWithStream to PATH"
+      - name: "Set NGINX_EXE for integration tests"
         run: |
-          # This is necessary for ohttp-relay integration tests
-          echo "$(nix build .#nginx-with-stream --print-out-paths --no-link)/bin" >> $GITHUB_PATH
+          echo "NGINX_EXE=$(nix build .#nginx-with-stream --print-out-paths --no-link)/bin/nginx" >> $GITHUB_ENV
       - name: "Use cache"
         uses: Swatinem/rust-cache@v2
       - name: "Install cargo-llvm-cov"


### PR DESCRIPTION
# Set NGINX_EXE env var in CI workflow

## Summary

The ohttp-relay integration tests use the `NGINX_EXE` environment variable to
locate the nginx binary (introduced in #1237). However, the GitHub Actions CI
workflow was still using the old approach of adding nginx to `$GITHUB_PATH`
instead of setting `NGINX_EXE`. This meant the integration tests were silently
skipped in CI since `NGINX_EXE` was not set.

This PR updates both the Test and Coverage jobs in the CI workflow to set
`NGINX_EXE` via `$GITHUB_ENV`, pointing to the full path of the nginx binary
built from the `nginx-with-stream` nix package.

## Changes

- `.github/workflows/rust.yml`: Replace `$GITHUB_PATH` with `$GITHUB_ENV` to
  set `NGINX_EXE` to the full binary path in both Test and Coverage jobs

## Test plan

- [ ] CI Test job runs ohttp-relay integration tests (no longer skipped)
- [ ] CI Coverage job runs ohttp-relay integration tests (no longer skipped)

Closes #1227

Disclosure: co-authored by claude-code
