### PR TITLE
Enable CodeRabbit reviews on draft PRs

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -5,9 +5,14 @@ reviews:
   high_level_summary: false
   changed_files_summary: false
   sequence_diagrams: false
+  poem: false
+  review_status: false
+  collapse_walkthrough: true
   estimate_code_review_effort: false
   suggested_labels: false
   suggested_reviewers: false
+  auto_review:
+    drafts: true
   path_instructions:
     - path: "payjoin/src/**/*.rs"
       instructions: |


### PR DESCRIPTION
## Summary
CodeRabbit skips draft PRs by default, posting a "Review skipped - Draft detected" status message. Since we use draft PRs for work-in-progress feedback, we want CodeRabbit to review them.

Additionally, the `review_status` messages (posted inside the walkthrough summary comment) are disabled because CodeRabbit already reports review progress via GitHub commit status checks (`commit_status`, enabled by default). The commit status shows "pending" during review and "success" on completion, so the in-comment status messages are redundant noise.

## Approach
- Set `reviews.auto_review.drafts: true` to include draft PRs in automatic reviews
- Set `reviews.review_status: false` to suppress the walkthrough status messages, since `commit_status` (default: true) provides the same signal via GitHub's native commit status API

## Open questions
- If the commit status check turns out to be insufficient (e.g., not visible enough), `review_status` can be re-enabled

Disclosure: co-authored by Claude
