### PR TITLE
Disable all CodeRabbit noise, keep only path reviews

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -9,10 +9,22 @@ reviews:
   review_status: false
   collapse_walkthrough: true
   estimate_code_review_effort: false
+  assess_linked_issues: false
+  related_issues: false
+  related_prs: false
   suggested_labels: false
   suggested_reviewers: false
+  in_progress_fortune: false
+  enable_prompt_for_ai_agents: false
   auto_review:
     drafts: true
+  pre_merge_checks:
+    description:
+      mode: "off"
+    title:
+      mode: "off"
+    issue_assessment:
+      mode: "off"
   path_instructions:
     - path: "payjoin/src/**/*.rs"
       instructions: |


### PR DESCRIPTION
## Summary

Strip all CodeRabbit noise so it only does one thing: inline review
comments driven by `path_instructions`. Everything else is off.

**Disabled:**
- PR description summary injection (`high_level_summary`)
- Description/title/issue pre-merge checks (the "description check" CI status)
- Walkthrough fortune, poem, effort estimate
- Related issues/PRs, suggested labels/reviewers
- "Prompt for AI Agents" section
- File change summary, sequence diagrams
- Review status messages

**Kept:**
- Path-scoped inline review (C-CALLER-CONTROL + Rust API guidelines)
- Commit status check (so you can see if CodeRabbit ran)
- Draft PR auto-review

## Approach

Set every boolean noise feature to `false` and every pre-merge check
mode to `"off"`. The walkthrough comment can't be fully suppressed
but is collapsed and stripped of all content sections.

## Open questions

- If the walkthrough comment is still too noisy even empty/collapsed,
  the nuclear option is disabling `auto_review.enabled` and only
  triggering via `@coderabbitai review` on specific PRs.

<details>
  <summary>Pull Request Checklist</summary>

- [x] I have disclosed my use of AI in the body of this PR.
- [x] I have read CONTRIBUTING.md and rebased my branch to produce hygienic commits.
</details>

Disclosure: co-authored by Claude
