### PR TITLE
Search explicit public repos instead of org

### DIFF
--- a/.github/scripts/create_standup_discussion.py
+++ b/.github/scripts/create_standup_discussion.py
@@ -22,7 +22,25 @@ _CONFIG_PATH = Path(__file__).resolve().parent.parent / "standup-contributors.ym
 with open(_CONFIG_PATH) as _f:
     CONTRIBUTORS = [c["username"] for c in yaml.safe_load(_f)["contributors"]]
 
-ORG = "payjoin"
+# Public repos to search — explicit list avoids leaking private repo
+# data when the bot token has org membership.
+REPOS = [
+    "payjoin/rust-payjoin",
+    "payjoin/payjoin.org",
+    "payjoin/payjoindevkit.org",
+    "payjoin/cja",
+    "payjoin/cja-2",
+    "payjoin/bitcoin-hpke",
+    "payjoin/ohttp",
+    "payjoin/bitcoin_uri",
+    "payjoin/bitcoin-uri-ffi",
+    "payjoin/research-docs",
+    "payjoin/multiparty-protocol-docs",
+    "payjoin/btsim",
+    "payjoin/tx-indexer",
+]
+
+REPO_BATCH_SIZE = 5
 
 
 def get_repo_node_id():
@@ -102,14 +120,23 @@ def add_discussion_comment(discussion_id, body):
 
 
 def search_issues(query):
-    """Run a GitHub search/issues query and return the items."""
-    resp = requests.get(
-        f"{API}/search/issues",
-        headers=HEADERS,
-        params={"q": query, "per_page": 30},
-    )
-    resp.raise_for_status()
-    return resp.json().get("items", [])
+    """Run a GitHub search/issues query across REPOS in batches."""
+    seen = set()
+    items = []
+    for i in range(0, len(REPOS), REPO_BATCH_SIZE):
+        batch = REPOS[i : i + REPO_BATCH_SIZE]
+        repo_filter = " ".join(f"repo:{r}" for r in batch)
+        resp = requests.get(
+            f"{API}/search/issues",
+            headers=HEADERS,
+            params={"q": f"{query} {repo_filter}", "per_page": 30},
+        )
+        resp.raise_for_status()
+        for item in resp.json().get("items", []):
+            if item["id"] not in seen:
+                seen.add(item["id"])
+                items.append(item)
+    return items
 
 
 def gather_activity(user, since_date):
@@ -117,19 +144,15 @@ def gather_activity(user, since_date):
     since = since_date.strftime("%Y-%m-%d")
 
     # PRs merged (authored)
-    merged_prs = search_issues(f"author:{user} org:{ORG} type:pr merged:>{since}")
+    merged_prs = search_issues(f"author:{user} type:pr merged:>{since}")
 
     # PRs reviewed
-    reviewed_prs = search_issues(
-        f"reviewed-by:{user} org:{ORG} type:pr updated:>{since}"
-    )
+    reviewed_prs = search_issues(f"reviewed-by:{user} type:pr updated:>{since}")
     # Exclude PRs the user authored (already counted above)
     reviewed_prs = [pr for pr in reviewed_prs if pr["user"]["login"] != user]
 
     # Issues opened
-    issues_opened = search_issues(
-        f"author:{user} org:{ORG} type:issue created:>{since}"
-    )
+    issues_opened = search_issues(f"author:{user} type:issue created:>{since}")
 
     return merged_prs, reviewed_prs, issues_opened
 
@@ -141,14 +164,14 @@ def gather_potential_bottlenecks(user, since_date):
 
     # Open PRs with no reviews
     open_prs = search_issues(
-        f"author:{user} org:{ORG} type:pr state:open review:none created:>{since}"
+        f"author:{user} type:pr state:open review:none created:>{since}"
     )
     for pr in open_prs:
         bottlenecks.append(f"- PR awaiting review: [{pr['title']}]({pr['html_url']})")
 
     # PRs with requested changes
     changes_requested = search_issues(
-        f"author:{user} org:{ORG} type:pr state:open review:changes_requested"
+        f"author:{user} type:pr state:open review:changes_requested"
     )
     for pr in changes_requested:
         bottlenecks.append(


### PR DESCRIPTION
The bot token is an org member, so org:payjoin searches return results from private repos. Those titles and URLs would be published into the public Discussion, leaking private work.

Replace the org: search qualifier with explicit repo: qualifiers for each public repo to ensure only public activity is surfaced.

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [ ] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [ ] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
